### PR TITLE
[metallb] do not require NET_RAW capability

### DIFF
--- a/metallb/base/deployment.yaml
+++ b/metallb/base/deployment.yaml
@@ -42,11 +42,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-            - all
-            add:
-            - net_raw
 
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
MetalLB requires NET_RAW only when it is run in L2 mode.
In Neco, it is run in BGP mode hence does not require NET_RAW.